### PR TITLE
chore: initial implementation copied from @japa/assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 This package contains the OpenAPI Assertion tests that used to be included in `@japa/assert`
 
 ## Installation
+
 Install the package from the npm registry as follows:
 
 ```sh
@@ -25,18 +26,20 @@ You can use the assertion package with the `@japa/runner` as follows, registerin
 import { openapi } from '@japa/openapi-assertions'
 
 configure({
-  plugins: [openapi({
-    schemas: [new URL('../api-spec.json', import.meta.url)]
-  })]
+  plugins: [
+    openapi({
+      schemas: [new URL('../api-spec.json', import.meta.url)],
+    }),
+  ],
 })
 ```
 
 In tests you can validate API responses as follows:
 
 ```ts
-test('get users', ({ openapi }) => {
+test('get users', ({ assert }) => {
   const response = await supertest(baseUrl).get('/users')
-  openapi.isValidResponse(response)
+  assert.isValidResponse(response)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,43 @@
 
 ## Introduction
 
+This package contains the OpenAPI Assertion tests that used to be included in `@japa/assert`
+
+## Installation
+Install the package from the npm registry as follows:
+
+```sh
+npm i @japa/assert
+
+yarn add @japa/assert
+```
+
 ## Official Documentation
+
+You can use the assertion package with the `@japa/runner` as follows, registering an OpenAPI Schema:
+
+```ts
+import { openapi } from '@japa/openapi-assertions'
+
+configure({
+  plugins: [openapi({
+    schemas: [new URL('../api-spec.json', import.meta.url)]
+  })]
+})
+```
+
+In tests you can validate API responses as follows:
+
+```ts
+test('get users', ({ openapi }) => {
+  const response = await supertest(baseUrl).get('/users')
+  openapi.isValidResponse(response)
+})
+```
 
 ## Contributing
 
-One of the primary goals of japa is to have a vibrant community of users and contributors who believes in the principles of the framework.
+One of the primary goals of Japa is to have a vibrant community of users and contributors who believes in the principles of the framework.
 
 We encourage you to read the [contribution guide](https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md) before contributing to the framework.
 
@@ -20,7 +52,7 @@ In order to ensure that the japa community is welcoming to all, please review an
 
 ## License
 
-<pkg-name> is open-sourced software licensed under the [MIT license](LICENSE.md).
+@japa/openapi-assertions is open-sourced software licensed under the [MIT license](LICENSE.md).
 
 [gh-workflow-image]: https://img.shields.io/github/actions/workflow/status/japa/openapi-assertions/checks.yml?style=for-the-badge
 [gh-workflow-url]: https://github.com/japa/openapi-assertions/actions/workflows/checks.yml 'Github action'

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This package contains the OpenAPI Assertion tests that used to be included in `@
 Install the package from the npm registry as follows:
 
 ```sh
-npm i @japa/assert
+npm i @japa/openapi-assertions
 
-yarn add @japa/assert
+yarn add @japa/openapi-assertions
 ```
 
 ## Official Documentation
@@ -42,7 +42,7 @@ test('get users', ({ openapi }) => {
 
 ## Contributing
 
-One of the primary goals of Japa is to have a vibrant community of users and contributors who believes in the principles of the framework.
+One of the primary goals of japa is to have a vibrant community of users and contributors who believes in the principles of the framework.
 
 We encourage you to read the [contribution guide](https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md) before contributing to the framework.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In tests you can validate API responses as follows:
 ```ts
 test('get users', ({ assert }) => {
   const response = await supertest(baseUrl).get('/users')
-  assert.isValidResponse(response)
+  assert.isValidApiResponse(response)
 })
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import { Assert } from '@japa/assert'
 
 declare module '@japa/assert' {
   export interface Assert {
-    isValidResponse: (response: any) => void
+    isValidApiResponse: (response: any) => Chai.Assertion
   }
 }
 
@@ -28,7 +28,9 @@ export function openapi(options: PluginConfig): PluginFn {
     reportCoverage: options.reportCoverage,
   })
   return function () {
-    Assert.macro('isValidResponse', (response) => new OpenApiAssertions().isValidResponse(response))
+    Assert.macro('isValidApiResponse', (response) =>
+      new OpenApiAssertions().isValidResponse(response)
+    )
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,36 @@
+/*
+ * @japa/assert
+ *
+ * (c) Japa.dev
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { PluginFn } from '@japa/runner/types'
+import { TestContext } from '@japa/runner/core'
+
+import { OpenApiAssertions } from './src/openapi_assertions.js'
+import type { PluginConfig } from './src/types.js'
+
+declare module '@japa/runner/core' {
+  interface TestContext {
+    openapi: OpenApiAssertions
+  }
+}
+
+/**
+ * Plugin for "@japa/runner"
+ */
+export function openApi(options: PluginConfig): PluginFn {
+  OpenApiAssertions.registerSpecs(options.schemas, {
+    exportCoverage: options.exportCoverage,
+    reportCoverage: options.reportCoverage,
+  })
+
+  return function () {
+    TestContext.getter('openapi', () => new OpenApiAssertions(), true)
+  }
+}
+
+export { OpenApiAssertions }

--- a/index.ts
+++ b/index.ts
@@ -8,14 +8,14 @@
  */
 
 import type { PluginFn } from '@japa/runner/types'
-import { TestContext } from '@japa/runner/core'
 
 import { OpenApiAssertions } from './src/openapi_assertions.js'
 import type { PluginConfig } from './src/types.js'
+import { Assert } from '@japa/assert'
 
-declare module '@japa/runner/core' {
-  interface TestContext {
-    openapi: OpenApiAssertions
+declare module '@japa/assert' {
+  export interface Assert {
+    isValidResponse: (response: any) => void
   }
 }
 
@@ -27,9 +27,8 @@ export function openapi(options: PluginConfig): PluginFn {
     exportCoverage: options.exportCoverage,
     reportCoverage: options.reportCoverage,
   })
-
   return function () {
-    TestContext.getter('openapi', () => new OpenApiAssertions(), true)
+    Assert.macro('isValidResponse', (response) => new OpenApiAssertions().isValidResponse(response))
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ declare module '@japa/runner/core' {
 /**
  * Plugin for "@japa/runner"
  */
-export function openApi(options: PluginConfig): PluginFn {
+export function openapi(options: PluginConfig): PluginFn {
   OpenApiAssertions.registerSpecs(options.schemas, {
     exportCoverage: options.exportCoverage,
     reportCoverage: options.reportCoverage,

--- a/index.ts
+++ b/index.ts
@@ -10,12 +10,12 @@
 import type { PluginFn } from '@japa/runner/types'
 
 import { OpenApiAssertions } from './src/openapi_assertions.js'
-import type { PluginConfig } from './src/types.js'
+import type { OpenApiAssertionsContract, PluginConfig } from './src/types.js'
 import { Assert } from '@japa/assert'
 
 declare module '@japa/assert' {
   export interface Assert {
-    isValidApiResponse: (response: any) => Chai.Assertion
+    isValidApiResponse: OpenApiAssertionsContract['isValidResponse']
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 /*
- * @japa/assert
+ * @japa/openapi-assertions
  *
  * (c) Japa.dev
  *

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "build",
     "!build/bin",
-    "!build/tests"
+    "!build/tests",
+    "!build/tests_helpers"
   ],
   "main": "build/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@japa/openapi-assertions",
   "description": "OpenAPI Assertions plugin for Japa",
-  "version": "v0.0.0",
+  "version": "0.0.0",
   "engines": {
     "node": ">=20.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@japa/openapi-assertions",
-  "description": "",
-  "version": "0.0.0",
+  "description": "OpenAPI Assertions plugin for Japa",
+  "version": "v0.0.0",
   "engines": {
     "node": ">=20.6.0"
   },
@@ -48,6 +48,12 @@
     "ts-node-maintained": "^10.9.4",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "dependencies": {
+    "@poppinss/macroable": "^1.0.2",
+    "@types/chai": "^4.3.14",
+    "api-contract-validator": "^2.2.8",
+    "chai": "^5.1.0"
   },
   "homepage": "https://github.com/japa/openapi-assertions#readme",
   "repository": {
@@ -105,7 +111,8 @@
       "html"
     ],
     "exclude": [
-      "tests/**"
+      "tests/**",
+      "tests_helpers/**"
     ]
   },
   "prettier": "@adonisjs/prettier-config"

--- a/src/openapi_assertions.ts
+++ b/src/openapi_assertions.ts
@@ -7,10 +7,10 @@
  * file that was distributed with this source code.
  */
 
+import { expect, use } from 'chai'
 import { fileURLToPath } from 'node:url'
 import Macroable from '@poppinss/macroable'
 import { chaiPlugin } from 'api-contract-validator'
-import { expect, use } from 'chai'
 import { OpenApiAssertionsContract } from './types.js'
 
 /**

--- a/src/openapi_assertions.ts
+++ b/src/openapi_assertions.ts
@@ -1,0 +1,48 @@
+/*
+ * @japa/openapi-assertions
+ *
+ * (c) Japa.dev
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { fileURLToPath } from 'node:url'
+import Macroable from '@poppinss/macroable'
+import { chaiPlugin } from 'api-contract-validator'
+import { expect, use } from 'chai'
+import { OpenApiAssertionsContract } from './types.js'
+
+/**
+ *
+ */
+export class OpenApiAssertions extends Macroable implements OpenApiAssertionsContract {
+  protected static hasInstalledApiValidator = false
+
+  /**
+   * Register api specs to be used for validating responses
+   */
+  static registerSpecs(
+    schemaPathsOrURLs: (string | URL)[],
+    options?: { reportCoverage?: boolean; exportCoverage?: boolean }
+  ) {
+    this.hasInstalledApiValidator = true
+    const paths = schemaPathsOrURLs.map((schemaPathsOrURL) => {
+      return schemaPathsOrURL instanceof URL ? fileURLToPath(schemaPathsOrURL) : schemaPathsOrURL
+    })
+
+    use(chaiPlugin({ apiDefinitionsPath: paths, ...options }))
+  }
+
+  /**
+   * Assert the response confirms to open API spec
+   */
+  isValidResponse(response: any) {
+    // @ts-ignore
+    if (!this.constructor['hasInstalledApiValidator']) {
+      throw new Error('Cannot validate responses without defining api schemas')
+    }
+
+    return expect(response).to.matchApiSchema()
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@
  */
 
 export type OpenApiAssertionsContract = {
-  isValidResponse(response: any): void
+  isValidResponse: (response: any) => Chai.Assertion
 }
 
 export type PluginConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+/*
+ * @japa/openapi-assertions
+ *
+ * (c) Japa.dev
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export type OpenApiAssertionsContract = {
+  isValidResponse(response: any): void
+}
+
+export type PluginConfig = {
+  schemas: (string | URL)[]
+  reportCoverage?: boolean
+  exportCoverage?: boolean
+}

--- a/tests/fixtures/api-spec.json
+++ b/tests/fixtures/api-spec.json
@@ -1,0 +1,898 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "schemes": ["https", "http"],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      },
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["available", "pending", "sold"],
+              "default": "available"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use         tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied",
+            "schema": {
+              "type": "object",
+              "required": ["message"],
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file to upload",
+            "required": false,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10.         Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "maximum": 10,
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value.         Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "integer",
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            },
+            "headers": {
+              "X-Rate-Limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "calls per hour allowed by the user"
+              },
+              "X-Expires-After": {
+                "type": "string",
+                "format": "date-time",
+                "description": "date in UTC when token expires"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    },
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "description": "Order Status",
+          "enum": ["placed", "approved", "delivered"]
+        },
+        "complete": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "xml": {
+        "name": "Order"
+      }
+    },
+    "Category": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Category"
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      },
+      "xml": {
+        "name": "User"
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Tag"
+      }
+    },
+    "Pet": {
+      "type": "object",
+      "required": ["name", "photoUrls"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        },
+        "photoUrls": {
+          "type": "array",
+          "xml": {
+            "name": "photoUrl",
+            "wrapped": true
+          },
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "xml": {
+            "name": "tag",
+            "wrapped": true
+          },
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "pet status in the store",
+          "enum": ["available", "pending", "sold"]
+        }
+      },
+      "xml": {
+        "name": "Pet"
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  }
+}

--- a/tests/maths.spec.ts
+++ b/tests/maths.spec.ts
@@ -1,8 +1,0 @@
-import { test } from '@japa/runner'
-
-test.group('Maths.add', () => {
-  test('add two numbers', ({ expect }) => {
-    // Test logic goes here
-    expect(1 + 1).toBe(2)
-  })
-})

--- a/tests/openapi_assertions.spec.ts
+++ b/tests/openapi_assertions.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * @japa/openapi-assertions
+ *
+ * (c) Japa.dev
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { dirname, resolve } from 'node:path'
+import { OpenApiAssertions } from '../src/openapi_assertions.js'
+import { expectError } from '../tests_helpers/index.js'
+import { fileURLToPath } from 'node:url'
+
+test.group('When OpenApi is not configured', () => {
+  test('fails when assertions are called', () => {
+    const openApi = new OpenApiAssertions()
+
+    expectError(() => {
+      openApi.isValidResponse({
+        path: '/v2/pet/1',
+        method: 'get',
+        status: 200,
+        body: {},
+        headers: {},
+      })
+    }, 'Cannot validate responses without defining api schemas')
+  })
+})
+
+test.group('When OpenApi is configured with string schema path', (group) => {
+  group.setup(() => {
+    const directory = dirname(fileURLToPath(import.meta.url))
+    const schemaPath = resolve(directory, './fixtures/api-spec.json')
+
+    OpenApiAssertions.registerSpecs([schemaPath])
+  })
+
+  test('pass when response confirms to the api spec', () => {
+    const openApi = new OpenApiAssertions()
+
+    openApi.isValidResponse({
+      path: '/v2/pet/1',
+      method: 'get',
+      status: 200,
+      body: {
+        name: 'Pet 1',
+        photoUrls: ['/a', 'b'],
+      },
+      headers: {},
+    })
+  })
+})
+
+test.group('When OpenApi is configured', (group) => {
+  group.setup(() => {
+    OpenApiAssertions.registerSpecs([new URL('./fixtures/api-spec.json', import.meta.url)])
+  })
+
+  test('pass when response confirms to the api spec', () => {
+    const openApi = new OpenApiAssertions()
+
+    openApi.isValidResponse({
+      path: '/v2/pet/1',
+      method: 'get',
+      status: 200,
+      body: {
+        name: 'Pet 1',
+        photoUrls: ['/a', 'b'],
+      },
+      headers: {},
+    })
+  })
+
+  test('fail when response does not confirms to the api spec', () => {
+    const openApi = new OpenApiAssertions()
+
+    expectError(() => {
+      openApi.isValidResponse({
+        path: '/v2/pet/1',
+        method: 'get',
+        status: 200,
+        body: {},
+        headers: {},
+      })
+    }, 'expected response to match API schema')
+  })
+
+  test('validate error messages response', () => {
+    const openApi = new OpenApiAssertions()
+
+    openApi.isValidResponse({
+      path: '/v2/pet/1',
+      method: 'get',
+      status: 400,
+      body: {
+        message: 'Invalid id',
+      },
+      headers: {},
+    })
+  })
+
+  test('fail when response status code is not in the spec', () => {
+    const openApi = new OpenApiAssertions()
+
+    expectError(() => {
+      openApi.isValidResponse({
+        path: '/v2/pet/1',
+        method: 'get',
+        status: 401,
+        body: {},
+        headers: {},
+      })
+    }, 'schema not found for {"path":"/v2/pet/1","method":"get","status":401}')
+  })
+
+  test('fail when endpoint is not in the spec', () => {
+    const openApi = new OpenApiAssertions()
+
+    expectError(() => {
+      openApi.isValidResponse({
+        path: '/v2/pets/1',
+        method: 'get',
+        status: 200,
+        body: {},
+        headers: {},
+      })
+    }, 'schema not found for {"path":"/v2/pets/1","method":"get","status":200}')
+  })
+
+  test('fail when response headers mis-match', () => {
+    const openApi = new OpenApiAssertions()
+
+    expectError(() => {
+      openApi.isValidResponse({
+        path: '/v2/user/login',
+        method: 'get',
+        status: 200,
+        body: 'dads',
+        headers: {
+          'x-rate-limit': 'abc',
+        },
+      })
+    }, 'expected response to match API schema')
+  })
+})

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * @japa/assert
+ *
+ * (c) Japa.dev
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { assert as chaiAssert } from 'chai'
+import { TestContext, Test, Emitter, Refiner } from '@japa/runner/core'
+
+import { openApi } from '../index.js'
+import { OpenApiAssertions } from '../src/openapi_assertions.js'
+import { wrapAssertions } from '../tests_helpers/index.js'
+
+test.group('Plugin', () => {
+  test('add openapi property to test context', async () => {
+    const emitter = new Emitter()
+
+    openApi({
+      schemas: [new URL('./fixtures/api-spec.json', import.meta.url)],
+    })({
+      cliArgs: {},
+      config: {} as any,
+      emitter: emitter,
+      runner: {} as any,
+    })
+
+    const refiner = new Refiner()
+    const getContext = (t: Test<any>) => new TestContext(t)
+
+    const testInstance = new Test('test 1', getContext, emitter, refiner)
+    testInstance.run(async (ctx) => {
+      ctx.assert.plan(1)
+    })
+
+    wrapAssertions(() => {
+      chaiAssert.isDefined(getContext(testInstance)['openapi'])
+      chaiAssert.instanceOf(getContext(testInstance)['openapi'], OpenApiAssertions)
+    })
+  })
+})

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -12,11 +12,10 @@ import { assert as chaiAssert } from 'chai'
 import { TestContext, Test, Emitter, Refiner } from '@japa/runner/core'
 
 import { openapi } from '../index.js'
-import { OpenApiAssertions } from '../src/openapi_assertions.js'
 import { wrapAssertions } from '../tests_helpers/index.js'
 
 test.group('Plugin', () => {
-  test('add openapi property to test context', async () => {
+  test('add isValidApiResponse method to assert', async () => {
     const emitter = new Emitter()
 
     openapi({
@@ -32,13 +31,8 @@ test.group('Plugin', () => {
     const getContext = (t: Test<any>) => new TestContext(t)
 
     const testInstance = new Test('test 1', getContext, emitter, refiner)
-    testInstance.run(async (ctx) => {
-      ctx.assert.plan(1)
-    })
-
     wrapAssertions(() => {
-      chaiAssert.isDefined(getContext(testInstance)['openapi'])
-      chaiAssert.instanceOf(getContext(testInstance)['openapi'], OpenApiAssertions)
+      chaiAssert.isDefined(getContext(testInstance).assert.isValidApiResponse)
     })
   })
 })

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -11,7 +11,7 @@ import { test } from '@japa/runner'
 import { assert as chaiAssert } from 'chai'
 import { TestContext, Test, Emitter, Refiner } from '@japa/runner/core'
 
-import { openApi } from '../index.js'
+import { openapi } from '../index.js'
 import { OpenApiAssertions } from '../src/openapi_assertions.js'
 import { wrapAssertions } from '../tests_helpers/index.js'
 
@@ -19,7 +19,7 @@ test.group('Plugin', () => {
   test('add openapi property to test context', async () => {
     const emitter = new Emitter()
 
-    openApi({
+    openapi({
       schemas: [new URL('./fixtures/api-spec.json', import.meta.url)],
     })({
       cliArgs: {},

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -33,6 +33,8 @@ test.group('Plugin', () => {
     const testInstance = new Test('test 1', getContext, emitter, refiner)
     wrapAssertions(() => {
       chaiAssert.isDefined(getContext(testInstance).assert.isValidApiResponse)
+      chaiAssert.isFunction(getContext(testInstance).assert.isValidApiResponse)
+      chaiAssert.strictEqual(getContext(testInstance).assert.isValidApiResponse.length, 1)
     })
   })
 })

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,5 +1,5 @@
 /*
- * @japa/assert
+ * @japa/openapi-assertions
  *
  * (c) Japa.dev
  *

--- a/tests_helpers/index.ts
+++ b/tests_helpers/index.ts
@@ -1,0 +1,49 @@
+/*
+ * @japa/core
+ *
+ * (c) Japa.dev
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import * as chai from 'chai'
+import { ErrorsPrinter } from '@japa/errors-printer'
+
+export async function wrapAssertions(fn: () => void | Promise<void>) {
+  try {
+    await fn()
+  } catch (error) {
+    new ErrorsPrinter().printError(error)
+    throw new Error(error)
+  }
+}
+
+/**
+ * A modified copy of https://github.com/chaijs/chai/blob/a8359d3d15779a23a7957a4c52539d48de2763e0/test/bootstrap/index.js#L34
+ */
+export function expectError(fn: any, val?: any) {
+  try {
+    fn()
+  } catch (error) {
+    chai.expect(error).to.have.property('stack')
+
+    // @ts-expect-error not in @types/chai
+    switch (chai.util['type'](val).toLowerCase()) {
+      case 'undefined':
+        return
+      case 'string':
+        return chai.expect(error.message).to.equal(val)
+      case 'regexp':
+        return chai.expect(error.message).to.match(val)
+      case 'object':
+        return Object.keys(val).forEach(function (key) {
+          chai.expect(error).to.have.property(key).and.to.deep.equal(val[key])
+        })
+    }
+
+    throw new chai.AssertionError('Invalid val')
+  }
+
+  throw new chai.AssertionError('Expected an error')
+}


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds an initial version of the code required for this japa plugin.  It is exported as a `openapi` module, and exposed on the test context via `openapi`.

There's a few minor changes:

* Exposed as `openapi` on test context instead of on `assert`
* Renamed `assert.isValidApiResponse` to `openapi.isValidResponse`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
